### PR TITLE
Update 02.02.md

### DIFF
--- a/topic-05-models/unit-2/book-playtime-0-5-0/02.02.md
+++ b/topic-05-models/unit-2/book-playtime-0-5-0/02.02.md
@@ -126,7 +126,7 @@ The failing tests have usefully surfaced some bugs in playlist-json-store.
 
 #### delete One Playlist - fail
 
-This test failure is the result of a bug in `getPlaylistById()`
+This test failure is the result of a bug in `getPlaylistById()` // Is this get or delete? The function doesn't match the instruction
 
 ~~~javascript
   async deletePlaylistById(id) {


### PR DESCRIPTION
 // Is this get or delete? The function doesn't match the instruction

This test failure is the result of a bug in `getPlaylistById()`

~~~javascript
  async deletePlaylistById(id) {
    await db.read();
    const index = db.data.playlists.findIndex((playlist) => playlist._id === id);
    db.data.playlists.splice(index, 1);
    await db.write();
  },